### PR TITLE
Fix: Corrige base path para deploy no GitHub Pages

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,7 +4,7 @@ import { VitePWA } from 'vite-plugin-pwa'
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  base: '/psicontrato/',
+  base: '/psicontratos/',
   plugins: [
     react(),
     VitePWA({


### PR DESCRIPTION
A configuração 'base' no vite.config.ts foi atualizada de '/psicontrato/' para '/psicontratos/' para corresponder ao nome do repositório no GitHub e corrigir o erro 404 no GitHub Pages.